### PR TITLE
[박솔찬] 회원가입 기능 구현 및 Stylesheet 지원

### DIFF
--- a/src/main/java/http/common/MediaType.java
+++ b/src/main/java/http/common/MediaType.java
@@ -11,7 +11,8 @@ public enum MediaType {
     IMAGE_PNG("image/png", "png"),
     AUDIO_MPEG("audio/mpeg", "mpeg"),
     AUDIO_OGG("audio.ogg", "ogg"),
-    VIDEO_MP4("video/mp4", "mp4");
+    VIDEO_MP4("video/mp4", "mp4"),
+    FAVICON("image/avif,image/webp,image/apng,image/svg+xml", "ico"),;
 
     private final String type;
     private final String extension;

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -37,24 +37,4 @@ public class RequestHandler implements Runnable {
         }
 
     }
-
-//    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
-//        try {
-//            dos.writeBytes("HTTP/1.1 200 OK \r\n");
-//            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
-//            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
-//            dos.writeBytes("\r\n");
-//        } catch (IOException e) {
-//            logger.error(e.getMessage());
-//        }
-//    }
-//
-//    private void responseBody(DataOutputStream dos, byte[] body) {
-//        try {
-//            dos.write(body, 0, body.length);
-//            dos.flush();
-//        } catch (IOException e) {
-//            logger.error(e.getMessage());
-//        }
-//    }
 }

--- a/src/test/java/controller/SignUpControllerTest.java
+++ b/src/test/java/controller/SignUpControllerTest.java
@@ -1,0 +1,47 @@
+package controller;
+
+import http.common.HttpHeaders;
+import http.common.HttpMethod;
+import http.common.HttpStatus;
+import http.common.URI;
+import http.request.HttpRequest;
+import http.response.HttpResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("SignupController Test")
+public class SignUpControllerTest {
+
+    @Test
+    @DisplayName("execute() - 회원가입 성공 후 리다이렉트 테스트")
+    void signUp() {
+        // given
+        SignUpController controller = new SignUpController();
+        Map<String, String> user = Map.of(
+                "userId", "sol",
+                "password", "1234",
+                "name", "sol",
+                "email", "sol@sol.com");
+        HttpRequest request = new HttpRequest(
+                HttpMethod.GET,
+                new URI("/user/create", user),
+                new HttpHeaders());
+        HttpResponse response = new HttpResponse();
+
+        // when
+        controller.execute(request, response);
+
+        // then
+        String redirect = response.getHeaders().getValue("Location");
+        HttpStatus status = response.getStatus();
+        assertAll(
+                () -> assertEquals("/user/login.html", redirect),
+                () -> assertEquals(HttpStatus.SEE_OTHER, status)
+        );
+    }
+}

--- a/src/test/java/utils/ResourceUtilsTest.java
+++ b/src/test/java/utils/ResourceUtilsTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import util.ResourceUtils;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayName("ResourceUtils Test")
@@ -26,10 +27,18 @@ public class ResourceUtilsTest {
     @DisplayName("loadFileFromClasspath() - static 디렉토리 파일 탐색 성공 케이스")
     void loadStaticFileFromClasspath() {
         // given
+        String pathOfCss = "/css/styles.css";
+        String pathOfJS = "/js/bootstrap.min.js";
 
         // when
+        byte[] css = ResourceUtils.loadFileFromClasspath(pathOfCss);
+        byte[] js = ResourceUtils.loadFileFromClasspath(pathOfJS);
 
         // then
+        assertAll(
+                () -> assertEquals(7065, css.length),
+                () -> assertEquals(31819, js.length)
+        );
     }
 
     @Test

--- a/src/test/java/utils/ResourceUtilsTest.java
+++ b/src/test/java/utils/ResourceUtilsTest.java
@@ -45,9 +45,12 @@ public class ResourceUtilsTest {
     @DisplayName("loadFileFromClasspath() - 파일이 존재하지 않는 케이스")
     void NoSearchFile() {
         // given
+        String invalidPath = "/no/search/file";
 
         // when
+        byte[] nodata = ResourceUtils.loadFileFromClasspath(invalidPath);
 
         // then
+        assertEquals(0, nodata.length);
     }
 }

--- a/src/test/java/utils/ResourceUtilsTest.java
+++ b/src/test/java/utils/ResourceUtilsTest.java
@@ -1,0 +1,44 @@
+package utils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import util.ResourceUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("ResourceUtils Test")
+public class ResourceUtilsTest {
+
+    @Test
+    @DisplayName("loadFileFromClasspath() - templates 디렉토리 파일 탐색 성공 케이스")
+    void loadTemplateFileFromClasspath() {
+        // given
+        String filePath = "/index.html";
+
+        // when
+        byte[] bytes = ResourceUtils.loadFileFromClasspath(filePath);
+
+        // then
+        assertEquals(6902, bytes.length);
+    }
+
+    @Test
+    @DisplayName("loadFileFromClasspath() - static 디렉토리 파일 탐색 성공 케이스")
+    void loadStaticFileFromClasspath() {
+        // given
+
+        // when
+
+        // then
+    }
+
+    @Test
+    @DisplayName("loadFileFromClasspath() - 파일이 존재하지 않는 케이스")
+    void NoSearchFile() {
+        // given
+
+        // when
+
+        // then
+    }
+}


### PR DESCRIPTION
회원가입 기능 구현 및 Stylesheet 지원

(이전 PR에 오늘 진행한 대부분의 기능 구현 커밋이 포함되어있습니다.)

## 진행 사항
1. 전체적인 요청 처리 구조 리팩토링
2. 회원가입 기능 구현
3. stylesheet 지원

## 전체적인 요청 처리 구조 리팩토링
기존에는 `RequestHandler`에서 단순 요청에 대한 특정 페이지 응답만 수행하였다.
하지만 요청 경로마다 각각 다른 요청을 처리해야하기에 아래와 같이 구조를 변경하였다.

ReqeustHandler에서  클라이언트 연결 시,
1. HttpRequest와 HttpResponse 생성하여 Dispatcher의 `handle` 메서드 호출하며 넘겨준다.
2. Dispathcher는 서빙할 파일, 경로에 맞는 컨트롤러를 호출하여 HttpResponse 객체에 결과 데이터를 담고 실행을 종료한다
3. RequestHandler는 데이터가 담아진 HttpResponse를 HttpResponseWriter에 넘겨 클라이언트에 응답한다.

만약, 처리 결과 데이터에 따라 뷰 렌더링이 진행된다면 HttpResponseWriter에게 넘기기 전 뷰를 완성한 뒤 응답하도록 진행해볼 예정이다.

## 회원가입 기능 구현
SignUpController를 작성하여 회원가입을 구현하였다.
중복 체크, 비밀번호 체크 등의 부가 로직 없이 단순 저장 기능만 가지고 있다.
회원가입 진행 후 HttpResponse의 헤더에 Location 속성을 추가하여 로그인 페이지로 리다이렉션을 한다.

## Stylesheet 지원
ResourceUtils를 통해 templates와 static 디렉토리를 탐색하여 파일을 찾는다.
찾은 파일의 확장자를 추출하여  Content-Type의 정보를 관리하는 MediaType Enum을 통해 일치하는 Content-Type을 설정하여 Stylesheet를 지원한다.

### 내일 할일
- 미리 작성하지 않았던 테스트 케이스를 찾아 작성할 예정이다.
- 만약, 동적으로 데이터를 바인딩하여 페이지를 응답한다면 어떻게 해야할지 찾아볼 예정이다.
