### PR TITLE
[박승민] Step2 & Step3 일차적으로 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,19 @@ Java Web Application Server 2022
 
 이 프로젝트는 우아한 테크코스 박재성님의 허가를 받아 https://github.com/woowacourse/jwp-was 
 를 참고하여 작성되었습니다.
+
+## Step 1 - index.html 응답
+최초의 상태는 localhost:8080으로 접속 시에 "Hello World"를 출력해준다. 이는 구현되어 있는 responseBody 메서드에 해당 문구를 byte[]로 변환하여 응답해주기 때문이다.
+
+응답으로 index.html을 넘겨주는 방식으로 개선하기 위해서는 
+1. 서버로 들어오는 inputLine에서 해당 url을 parsing
+2. parsing한 파일을 resources에서 찾아 byte[]로 변환
+3. 이를 response body에 write
+
+의 과정을 거쳐야 한다.
+index.html에 대한 HTTP Request 메시지의 첫 라인은 **GET /index.html HTTP/1.1**이다. 이것을
+1. split메서드를 통해 "/index.html"만을 parsing
+2. "index.html"이 있는 resource 디렉토리를 붙인 절대 경로로 Files.readAllBytes() 메서드의 인자로 넘겨 불러와 byte[]로 변환
+3. 이를 response body에 write
+
+하여 해결 가능하다.

--- a/src/main/java/util/HttpRequestUtils.java
+++ b/src/main/java/util/HttpRequestUtils.java
@@ -1,0 +1,30 @@
+package util;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class HttpRequestUtils {
+
+    public static Map<String, String> parseQuerystring(String queryString) {
+        Map<String, String> map = new HashMap<>();
+        if ((queryString == null) || (queryString.equals(""))) {
+            return map;
+        }
+        String[] params = queryString.split("&");
+        for (String param : params) {
+            String[] keyValuePair = param.split("=", 2);
+            String name = URLDecoder.decode(keyValuePair[0], StandardCharsets.UTF_8);
+            if (Objects.equals(name, "")) {
+                continue;
+            }
+            String value = keyValuePair.length > 1 ? URLDecoder.decode(
+                    keyValuePair[1], StandardCharsets.UTF_8) : "";
+            map.put(name, value);
+        }
+        return map;
+    }
+
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,18 +1,12 @@
 package webserver;
 
-import db.Database;
-import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.Socket;
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
@@ -31,7 +25,6 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-            // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             BufferedReader br = new BufferedReader(new InputStreamReader(in));
             String line = br.readLine();
             logger.debug("> input line : {}", line);
@@ -57,10 +50,10 @@ public class RequestHandler implements Runnable {
 
         byte[] body;
         if (substring.equals("html") || substring.equals("ico")) {
-            body = Files.readAllBytes(new File("src/main/resources/templates/" + url).toPath());
+            body = Files.readAllBytes(new File(ViewResolver.TEMPLATES_PATH + url).toPath());
             response200Header(dos, body.length, "text/html");
         } else{
-            body = Files.readAllBytes(new File("src/main/resources/static" + url).toPath());
+            body = Files.readAllBytes(new File(ViewResolver.STATIC_PATH + url).toPath());
             if (substring.equals("css")) {
                 response200Header(dos, body.length, "text/css");
             } else {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,7 +2,6 @@ package webserver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import util.HttpRequestUtils;
 
 import java.io.*;
 import java.net.Socket;
@@ -37,35 +36,18 @@ public class RequestHandler implements Runnable {
             logger.debug("> input line : {}", line);
             String url = getUrl(line);
             url = checkUrlQueryString(url);
+            logger.debug("> url : {}", url);
 
             DataOutputStream dos = new DataOutputStream(out);
+            Path path = viewResolver.findFilePath(url);
+            String contentType = Files.probeContentType(path);
+            byte[] body = viewResolver.findFileBytes(path);
 
-
-            byte[] body = viewResolver.findFilePath(url);
-
-
-            response200HeaderByExtension(url, body, dos);
+            response200Header(dos, body.length, contentType);
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
-    }
-
-    //TODO 리팩토링 필요!! src/main/resources/static/user/js/scripts.js 이렇게 옴.
-    private void response200HeaderByExtension(String url, byte[] body, DataOutputStream dos) throws IOException {
-        String extension = url.substring(url.lastIndexOf(".")+1);
-        logger.debug(">>> extension : {}", extension);
-
-        String contentType;
-        if (extension.equals("css")) {
-            contentType = "text/css";
-        } else if (extension.equals("js")) {
-            contentType = "text/javascript";
-        } else {
-            contentType = "text/html";
-        }
-        response200Header(dos, body.length, contentType);
-
     }
 
     private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,11 +2,15 @@ package webserver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import util.HttpRequestUtils;
 
 import java.io.*;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Map;
+
+import static util.HttpRequestUtils.parseQuerystring;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
@@ -66,10 +70,11 @@ public class RequestHandler implements Runnable {
     private String checkUrlQueryString(String url) {
         String[] queryStrings = url.split("\\?");
         if (queryStrings.length != 1) {
-            //userId=dd&password=&name=&email=ddd%40dd
             String queryString = queryStrings[1];
             logger.debug(">> {}", queryString);
-            userService.signUpUser(queryString);
+
+            Map<String, String> requestParams = parseQuerystring(queryString);
+            userService.signUpUser(requestParams);
 
             url = BASE_URL;
         }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -8,6 +8,7 @@ import java.io.*;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static util.HttpRequestUtils.parseQuerystring;
@@ -42,6 +43,7 @@ public class RequestHandler implements Runnable {
 
             byte[] body = viewResolver.findFilePath(url);
 
+
             response200HeaderByExtension(url, body, dos);
             responseBody(dos, body);
         } catch (IOException e) {
@@ -51,18 +53,19 @@ public class RequestHandler implements Runnable {
 
     //TODO 리팩토링 필요!! src/main/resources/static/user/js/scripts.js 이렇게 옴.
     private void response200HeaderByExtension(String url, byte[] body, DataOutputStream dos) throws IOException {
-        String substring = url.substring(url.lastIndexOf(".")+1);
-        logger.debug(">>> substring : {}", substring);
+        String extension = url.substring(url.lastIndexOf(".")+1);
+        logger.debug(">>> extension : {}", extension);
 
-        if (substring.equals("html") || substring.equals("ico")) {
-            response200Header(dos, body.length, "text/html");
-        } else{
-            if (substring.equals("css")) {
-                response200Header(dos, body.length, "text/css");
-            } else {
-                response200Header(dos, body.length, "text/javascript");
-            }
+        String contentType;
+        if (extension.equals("css")) {
+            contentType = "text/css";
+        } else if (extension.equals("js")) {
+            contentType = "text/javascript";
+        } else {
+            contentType = "text/html";
         }
+        response200Header(dos, body.length, contentType);
+
     }
 
     private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -33,14 +33,12 @@ public class RequestHandler implements Runnable {
             String line = br.readLine();
             logger.debug("> input line : {}", line);
             String url = getUrl(line);
-            logger.debug("> request url : {}", url);
-
             url = checkUrlQueryString(url);
+            logger.debug("> request url : {}", url);
 
             DataOutputStream dos = new DataOutputStream(out);
 
             byte[] body = response200HeaderByExtension(url, dos);
-
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
@@ -57,7 +55,9 @@ public class RequestHandler implements Runnable {
             body = Files.readAllBytes(new File(ViewResolver.TEMPLATES_PATH + url).toPath());
             response200Header(dos, body.length, "text/html");
         } else{
-            body = Files.readAllBytes(new File(ViewResolver.STATIC_PATH + url).toPath());
+            int indexOfRelativePath = url.lastIndexOf("/") + 1;
+            String fileName = url.substring(indexOfRelativePath);
+            body = Files.readAllBytes(new File(ViewResolver.STATIC_PATH + substring+"/" + fileName).toPath());
             if (substring.equals("css")) {
                 response200Header(dos, body.length, "text/css");
             } else {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -16,12 +16,14 @@ import java.util.Objects;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+    private final UserService userService;
 
     private Socket connection;
     private final String BASE_URL = "/index.html";
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
+        this.userService = new UserService();
     }
 
     public void run() {
@@ -74,44 +76,13 @@ public class RequestHandler implements Runnable {
             //userId=dd&password=&name=&email=ddd%40dd
             String queryString = queryStrings[1];
             logger.debug(">> {}", queryString);
-            signUpUser(queryString);
+            userService.signUpUser(queryString);
 
             url = BASE_URL;
         }
         return url;
     }
 
-    /**
-     * 회원가입 로직
-     */
-    private void signUpUser(String queryString) {
-        Map<String, String> requestParams = parseQuerystring(queryString);
-
-        User user = new User(requestParams.get("userId"),
-                requestParams.get("password"),
-                requestParams.get("name"),
-                requestParams.get("email"));
-        Database.addUser(user);
-    }
-
-    public Map<String, String> parseQuerystring(String queryString) {
-        Map<String, String> map = new HashMap<>();
-        if ((queryString == null) || (queryString.equals(""))) {
-            return map;
-        }
-        String[] params = queryString.split("&");
-        for (String param : params) {
-            String[] keyValuePair = param.split("=", 2);
-            String name = URLDecoder.decode(keyValuePair[0], StandardCharsets.UTF_8);
-            if (Objects.equals(name, "")) {
-                continue;
-            }
-            String value = keyValuePair.length > 1 ? URLDecoder.decode(
-                    keyValuePair[1], StandardCharsets.UTF_8) : "";
-            map.put(name, value);
-        }
-        return map;
-    }
 
     private String getUrl(String line) {
         //문자열 분리 후 -> 문자열 배열에 삽입

--- a/src/main/java/webserver/UserService.java
+++ b/src/main/java/webserver/UserService.java
@@ -2,16 +2,13 @@ package webserver;
 
 import db.Database;
 import model.User;
-import util.HttpRequestUtils;
 
 import java.util.Map;
 
 public class UserService {
 
 
-    public void signUpUser(String queryString) {
-        Map<String, String> requestParams = HttpRequestUtils.parseQuerystring(queryString);
-
+    public void signUpUser(Map<String, String> requestParams) {
         User user = new User(requestParams.get("userId"),
                 requestParams.get("password"),
                 requestParams.get("name"),

--- a/src/main/java/webserver/UserService.java
+++ b/src/main/java/webserver/UserService.java
@@ -1,0 +1,21 @@
+package webserver;
+
+import db.Database;
+import model.User;
+import util.HttpRequestUtils;
+
+import java.util.Map;
+
+public class UserService {
+
+
+    public void signUpUser(String queryString) {
+        Map<String, String> requestParams = HttpRequestUtils.parseQuerystring(queryString);
+
+        User user = new User(requestParams.get("userId"),
+                requestParams.get("password"),
+                requestParams.get("name"),
+                requestParams.get("email"));
+        Database.addUser(user);
+    }
+}

--- a/src/main/java/webserver/ViewResolver.java
+++ b/src/main/java/webserver/ViewResolver.java
@@ -14,19 +14,20 @@ public class ViewResolver {
     static final String STATIC_PATH = "src/main/resources/static/";
     static final String TEMPLATES_PATH = "src/main/resources/templates/";
 
-    public byte[] findFilePath(String url) throws IOException {
-        logger.debug(">> request url : {}", url);
-
+    public byte[] findFileBytes(Path path) throws IOException {
         try {
-            return Files.readAllBytes(new File(ViewResolver.STATIC_PATH + url).toPath());
+            return Files.readAllBytes(path);
         } catch (IOException e) {
-            return Files.readAllBytes(new File(ViewResolver.TEMPLATES_PATH + url).toPath());
+            return Files.readAllBytes(path);
         }
     }
 
-    public Path findPath(String url) {
-        return new File(ViewResolver.STATIC_PATH + url).toPath();
-
-
+    public Path findFilePath(String url) {
+        try {
+            Files.readAllBytes(new File(ViewResolver.STATIC_PATH + url).toPath());
+            return new File(ViewResolver.STATIC_PATH + url).toPath();
+        } catch (IOException e) {
+            return new File(ViewResolver.TEMPLATES_PATH + url).toPath();
+        }
     }
 }

--- a/src/main/java/webserver/ViewResolver.java
+++ b/src/main/java/webserver/ViewResolver.java
@@ -1,0 +1,8 @@
+package webserver;
+
+public class ViewResolver {
+
+    static final String STATIC_PATH = "src/main/resources/static";
+    static final String TEMPLATES_PATH = "src/main/resources/templates/";
+
+}

--- a/src/main/java/webserver/ViewResolver.java
+++ b/src/main/java/webserver/ViewResolver.java
@@ -1,8 +1,31 @@
 package webserver;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
 public class ViewResolver {
+    private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
     static final String STATIC_PATH = "src/main/resources/static/";
     static final String TEMPLATES_PATH = "src/main/resources/templates/";
 
+    public byte[] findFilePath(String url) throws IOException {
+        logger.debug("> request url : {}", url);
+
+        String substring = url.substring(url.lastIndexOf(".")+1);
+        logger.debug(">>> substring : {}", substring);
+
+        if (substring.equals("html") || substring.equals("ico")) {
+            return Files.readAllBytes(new File(ViewResolver.TEMPLATES_PATH + url).toPath());
+        } else{
+            int indexOfRelativePath = url.lastIndexOf("/") + 1;
+            String fileName = url.substring(indexOfRelativePath);
+            return Files.readAllBytes(new File(ViewResolver.STATIC_PATH + substring+"/" + fileName).toPath());
+        }
+    }
 }

--- a/src/main/java/webserver/ViewResolver.java
+++ b/src/main/java/webserver/ViewResolver.java
@@ -3,29 +3,30 @@ package webserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class ViewResolver {
-    private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(ViewResolver.class);
 
     static final String STATIC_PATH = "src/main/resources/static/";
     static final String TEMPLATES_PATH = "src/main/resources/templates/";
 
     public byte[] findFilePath(String url) throws IOException {
-        logger.debug("> request url : {}", url);
+        logger.debug(">> request url : {}", url);
 
-        String substring = url.substring(url.lastIndexOf(".")+1);
-        logger.debug(">>> substring : {}", substring);
-
-        if (substring.equals("html") || substring.equals("ico")) {
+        try {
+            return Files.readAllBytes(new File(ViewResolver.STATIC_PATH + url).toPath());
+        } catch (IOException e) {
             return Files.readAllBytes(new File(ViewResolver.TEMPLATES_PATH + url).toPath());
-        } else{
-            int indexOfRelativePath = url.lastIndexOf("/") + 1;
-            String fileName = url.substring(indexOfRelativePath);
-            return Files.readAllBytes(new File(ViewResolver.STATIC_PATH + substring+"/" + fileName).toPath());
         }
+    }
+
+    public Path findPath(String url) {
+        return new File(ViewResolver.STATIC_PATH + url).toPath();
+
+
     }
 }

--- a/src/main/java/webserver/ViewResolver.java
+++ b/src/main/java/webserver/ViewResolver.java
@@ -2,7 +2,7 @@ package webserver;
 
 public class ViewResolver {
 
-    static final String STATIC_PATH = "src/main/resources/static";
+    static final String STATIC_PATH = "src/main/resources/static/";
     static final String TEMPLATES_PATH = "src/main/resources/templates/";
 
 }

--- a/src/main/resources/templates/user/form.html
+++ b/src/main/resources/templates/user/form.html
@@ -75,7 +75,7 @@
 <div class="container" id="main">
    <div class="col-md-6 col-md-offset-3">
       <div class="panel panel-default content-main">
-          <form name="question" method="get" action="/user/create">
+          <form name="question" method="get" action="/create">
               <div class="form-group">
                   <label for="userId">사용자 아이디</label>
                   <input class="form-control" id="userId" name="userId" placeholder="User ID">

--- a/src/main/resources/templates/user/form.html
+++ b/src/main/resources/templates/user/form.html
@@ -75,7 +75,7 @@
 <div class="container" id="main">
    <div class="col-md-6 col-md-offset-3">
       <div class="panel panel-default content-main">
-          <form name="question" method="get" action="/create">
+          <form name="question" method="get" action="/user/create">
               <div class="form-group">
                   <label for="userId">사용자 아이디</label>
                   <input class="form-control" id="userId" name="userId" placeholder="User ID">

--- a/src/test/java/UserRequestHandlerTest.java
+++ b/src/test/java/UserRequestHandlerTest.java
@@ -2,6 +2,7 @@ import model.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.io.ByteArrayOutputStream;
@@ -29,13 +30,16 @@ public class UserRequestHandlerTest {
         //given
         User user = new User("test", "123123", "tester", "test@gmaill.com");
         byte[] emptyPayload = new byte[1001];
-
         // Using Mockito
         final Socket socket = mock(Socket.class);
         final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         when(socket.getOutputStream()).thenReturn(byteArrayOutputStream);
 
+        //given
 
+        //when
+
+        //then
     }
 
 }


### PR DESCRIPTION
## What
1. 회원가입 로직을 처리하는 UserService 클래스, 회원가입 시 들어오는 쿼리스트링에 대한 처리를 담당하는 HttpRequestUtils 클래스로 역할을 분리하였습니다.
2. 요청한 url에 알맞는 리소스를 찾는 과정이 복잡하여 별도의 ViewResolver 클래스를 분리하여 처리하도록 하였습니다.
3. View Resolver가 해당 리소스를 찾는 과정을 기존 확장자를 토대로 일일이 static과 templates 디렉토리를 구분하는 방식에서 Static디렉토리 내에서 확인해보고 없을 시 templates 디렉토리에서 찾고, 거기에도 없다면 Error 로그를 띄우는 방식으로 개선하였습니다.
4. 회원가입 시에는 301 redirect를 통해 index.html로 넘어갈 수 있도록 구현하였습니다.

## Why
1 & 2 & 3. 이렇게 리팩토링한 것이 보다 더 객체지향적인 코드라고 판단하였습니다.
4. 회원가입 시 url에 "/user/" 가 계속해서 추가되어 회원가입 이후 해당하는 리소스를 찾지 못하는 문제를  팀원분들과 함께 고민하였습니다. 크게 두 가지 방법이 고려되었는데, "/create"와 같은 특정 url에 대해 200이 아닌 301로 응답하여 index.html로 redirect시켜주는 방법과 리소스 파일 자체의 path를 수정하는 방안이었습니다. 처음에는 후자의 방법을 선택하였으나, 이후 논의를 거쳐 301로 redirection 응답하여 바로 index.html을 200응답으로 넘겨주는 방법이 이후 다양한 경우에 대해 더 적합한 방법이라 판단되어 변경하였습니다.
## How
1. HttpRequestUtils 클래스에 parseQuerystring() 을 static으로 지정하여  RequestParam 형태로 Map을 리턴하고 이를 UserService로 넘겨주어 저장되도록 하였습니다.
2 & 3. ViewResolver가 url에 해당하는 file path를 static 디렉토리에서 해당 url로 read해보고 없으면 발생하는 IOException을 바로 catch하여 templates디렉토리에서 동일한 로직을 수행합니다. 거기서도 찾지 못한다면 기존 방식처럼 IOException을 request handler가 catch하여 error로그로 해당 url을 찍습니다.
4. url에 "create"가 포함되어 있는 경우는 redirect시켜주는 방식으로 구현하였습니다. 이 또한 결국 url 특정 문구에 의존하고 있어 더 좋은 방법을 연구하여 개선해볼 예정입니다.