### PR TITLE
[공윤재] - Step3 RequestHandler클래스의 run() 메서드 역할 분리

### DIFF
--- a/src/main/java/utility/HttpRequestUtils.java
+++ b/src/main/java/utility/HttpRequestUtils.java
@@ -14,7 +14,7 @@ public class HttpRequestUtils {
     public static Map<String, String> parseQueryString(String queryString)  {
         String[] params = queryString.split("&");
 
-        if(params.length == 0)
+        if(params.length == 0 || params[0].isBlank())
             return null;
 
         return Stream.of(params).map((param) -> param.split("=")).collect(Collectors.toMap(a->a[0], a->a[1]));

--- a/src/main/java/utility/HttpResponse.java
+++ b/src/main/java/utility/HttpResponse.java
@@ -1,0 +1,62 @@
+package utility;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpResponse {
+    private static final Logger logger = LoggerFactory.getLogger(HttpResponse.class);
+
+    public final HttpStatusCode statusCode;
+    public String contentType;
+    public final String resourcePath;
+
+    private Map<String, String> header;
+            
+    public HttpResponse(String resourcePath, HttpStatusCode statusCode, Map<String, String> header) {
+        this.statusCode = statusCode;
+        this.resourcePath = resourcePath;
+        this.header = header;
+    }
+
+    public HttpResponse(String resourcePath, HttpStatusCode statusCode) {
+        this(resourcePath, statusCode, new HashMap<>());
+    }
+
+    public String of() throws IOException {
+        final String NEXT_LINE = " \r\n";
+        byte[] body = "".getBytes();
+
+        if(!resourcePath.isBlank()) {
+            try {
+                body = Files.readAllBytes(new File(resourcePath.toString()).toPath());
+            } catch (IOException e) {
+                logger.error("cannot open file: " + e.getMessage());
+            }
+        }
+
+        StringBuilder sb = new StringBuilder(String.format("%s %s \r\n", "HTTP/1.1", statusCode.toString()));
+        sb.append("Content-Type: text/" + contentType + ";charset=utf-8 \r\n");
+        sb.append("Content-Length: " + body.length + " \r\n");
+
+        // StatusCode specific header
+        for(Map.Entry<String, String> header : header.entrySet()) {
+            String key = header.getKey();
+            String val = header.getValue();
+
+            sb.append(key).append(": ").append(val).append(" \r\n");
+        }
+
+        responseBody(body, sb);
+
+        return sb.toString();
+    }
+
+    private void responseBody(byte[] body, StringBuilder sb) {
+        sb.append(body);
+    }
+}

--- a/src/main/java/utility/HttpStatusCode.java
+++ b/src/main/java/utility/HttpStatusCode.java
@@ -2,6 +2,7 @@ package utility;
 
 public enum HttpStatusCode {
     OK(200, "OK"),
+    NOT_FOUND(404, "NOT FOUND"),
     FOUND(302, "FOUND");
     private final int responseCode;
     private final String responseMessage;

--- a/src/main/java/webserver/RequestController.java
+++ b/src/main/java/webserver/RequestController.java
@@ -72,7 +72,10 @@ public class RequestController {
         }
         resourcePath.append(path);
 
-        return resourcePath.toString();
+        String contentType = Files.probeContentType(Path.of(path));
+        logger.debug("contentType: " +contentType);
+
+        return new HttpResponse(resourcePath.toString(), HttpStatusCode.OK, contentType);
     }
 
     public static String dynamicResourceController(String path, HttpRequestParser parser) throws IOException {
@@ -95,6 +98,9 @@ public class RequestController {
             // TODO: Redirect Response 보내기
         }
 
-        return "dynamic";  // TODO: HttpResponse 반환
+        String contentType = Files.probeContentType(Path.of(path));
+        logger.debug("contentType: " +contentType);
+
+        return new HttpResponse(path, status, header, contentType);
     }
 }

--- a/src/main/java/webserver/RequestController.java
+++ b/src/main/java/webserver/RequestController.java
@@ -6,10 +6,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import utility.HttpRequestParser;
 import utility.HttpResponse;
+import utility.HttpStatusCode;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class RequestController {
@@ -18,17 +21,16 @@ public class RequestController {
     정적 리소스는 단순 서빙
     동적 리소스의 경우 Redirect, 비즈니스 로직 처리 등 수행
     */
-
-    private static final Logger logger = LoggerFactory.getLogger(RequestController.class);
-
     public static final String DEFAULT_PATH = "./src/main/resources";
     public static final String TEMPLATES_PATH = "/templates";
     public static final String STATIC_PATH = "/static";
+    private static final Logger logger = LoggerFactory.getLogger(RequestController.class);
 
     private static final int DYNAMIC = 1;
     private static final int STATIC = 2;
 
     private static final List<String> staticResource = new ArrayList<>(Arrays.asList("js", "html", "css", "font", "woff"));
+
     public Map<String, Integer> resources;
 
     private static RequestController controller = null;
@@ -48,7 +50,7 @@ public class RequestController {
     }
 
     // TODO: HttpResponse 반환하게
-    public static String requestController(String resourcePath) throws IOException {
+    public static HttpResponse requestController(String resourcePath) throws IOException {
         HttpRequestParser requestParser = new HttpRequestParser(resourcePath);
         String path = requestParser.path;
 
@@ -61,8 +63,23 @@ public class RequestController {
 
     }
 
+    public static HttpResponse requestController(InputStream in) throws IOException {
+        HttpRequestParser requestParser = new HttpRequestParser(in);
+        String path = requestParser.path;
+
+        logger.debug("Request Path: " + path);
+
+        String[] args = path.split("\\.");
+
+        if(args.length >= STATIC)  // .min.js, .js, .html , .ico
+            return staticResourceController(requestParser.path);
+        else
+            return dynamicResourceController(requestParser.path, requestParser);
+
+    }
+
     // TODO: HttpResponse 반환하게
-    public static String staticResourceController(String path) {
+    public static HttpResponse staticResourceController(String path) throws IOException {
         StringBuilder resourcePath = new StringBuilder(DEFAULT_PATH);
 
         if(path.contains("html") || path.contains(".ico")) {
@@ -78,11 +95,15 @@ public class RequestController {
         return new HttpResponse(resourcePath.toString(), HttpStatusCode.OK, contentType);
     }
 
-    public static String dynamicResourceController(String path, HttpRequestParser parser) throws IOException {
+    public static HttpResponse dynamicResourceController(String path, HttpRequestParser parser) throws IOException {
+        // HttpResponse response = NotFoundResponse;
+        Map<String, String> header = new HashMap<>();
+        HttpStatusCode status = HttpStatusCode.NOT_FOUND;
 
-
-        if(path.equals("/"))
-            path = "/index.html"; // TODO: Redirect Response 보내기
+        if(path.equals("/")) {
+            path = "/index.html";
+            status = HttpStatusCode.OK;
+        }
 
         if(path.contains("/create") && parser.hasParams()) {
             Map<String, String> params = parser.getParams();
@@ -93,9 +114,13 @@ public class RequestController {
                     .setName(params.get("name"))
                     .setEmail(params.get("email")).build();
 
+            // TODO: UserService로 분리
             Database.addUser(user);
+
             logger.debug("created User: {}", Database.findUserById(params.get("userId")));
-            // TODO: Redirect Response 보내기
+
+            path = "";
+            header.put("Location", "/index.html");
         }
 
         String contentType = Files.probeContentType(Path.of(path));

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -80,7 +80,7 @@ public class RequestHandler implements Runnable {
             assert body!= null;
 
             if(path.contains("/create") && requestParser.hasParams()) {
-                response303Header(dos, 0, getContentType(path));
+                response302Header(dos, 0, getContentType(path));
             } else {
                 response200Header(dos, body.length, getContentType(path));
             }
@@ -112,9 +112,9 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private void response303Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
+    private void response302Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
         try {
-            dos.writeBytes("HTTP/1.1 303 SEE OTHER \r\n");
+            dos.writeBytes("HTTP/1.1 302 FOUND \r\n");
             dos.writeBytes("Location: /index.html \r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,14 +2,10 @@ package webserver;
 
 import java.io.*;
 import java.net.Socket;
-import java.nio.file.Files;
-import java.util.Map;
 
-import db.Database;
-import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import utility.HttpRequestParser;
+import utility.HttpResponse;
 
 public class RequestHandler implements Runnable {
 
@@ -28,106 +24,17 @@ public class RequestHandler implements Runnable {
         logger.debug("New Client Connect! Connected IP : {}, Port : {}", connection.getInetAddress(),
                 connection.getPort());
 
-        byte[] body = null;
-        FileInputStream uri = null;
-        StringBuilder resourcePath = new StringBuilder(DEFAULT_PATH);
-
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {  // try with resource
-            HttpRequestParser requestParser = new HttpRequestParser(in);
-
-            String path = requestParser.path;
-
-            logger.debug("request path: " + path);
-
-            // TODO: Controller 클래스로 아래 정적 리소스 라우팅 및 byte[] 뷰 반환 기능 위임
-            if(path.equals("/"))
-                path = "/index.html";
-
-            if(path.contains("/create") && requestParser.hasParams()) {
-                Map<String, String> params = requestParser.getParams();
-
-                User user = User.UserBuilder.builder()
-                        .setUserId(params.get("userId"))
-                        .setPassword(params.get("password"))
-                        .setName(params.get("name"))
-                        .setEmail(params.get("email")).build();
-
-                Database.addUser(user);
-                logger.debug("created User: {}", Database.findUserById(params.get("userId")));
-                // TODO: redirect
-            }
-
-            if(path.split("\\.").length >= 2) {
-                if (path.contains(".html") || path.contains(".ico")) {
-                    resourcePath.append(TEMPLATES_PATH);
-                } else {
-                    resourcePath.append(STATIC_PATH);
-                }
-                resourcePath.append(path);
-
-                // TODO: Controller 구현
-                try {
-                    body = Files.readAllBytes(new File(resourcePath.toString()).toPath());
-                } catch (FileNotFoundException e) {
-                    logger.error("Error while reading requested uri", e);
-                }
-            }
-
-            // end of controller
 
             DataOutputStream dos = new DataOutputStream(out);
 
-            assert body!= null;
+            HttpResponse response = RequestController.requestController(in);
+            dos = response.of(dos);
 
-            if(path.contains("/create") && requestParser.hasParams()) {
-                response302Header(dos, 0, getContentType(path));
-            } else {
-                response200Header(dos, body.length, getContentType(path));
-            }
-            responseBody(dos, body);
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private String getContentType(String path) {
-        String[] types = path.split("\\.");
-        String type = types[types.length-1];
-
-        if(type.equals("js")) {
-            type = "javascript";
-        }
-
-        return type;
-    }
-
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
-        try {
-            dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/" + contentType + ";charset=utf-8\r\n");
-            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void response302Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
-        try {
-            dos.writeBytes("HTTP/1.1 302 FOUND \r\n");
-            dos.writeBytes("Location: /index.html \r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void responseBody(DataOutputStream dos, byte[] body) {
-        try {
-            dos.write(body, 0, body.length);
             dos.flush();
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
+
 }

--- a/src/test/java/HttpRequestUtilsTest.java
+++ b/src/test/java/HttpRequestUtilsTest.java
@@ -5,13 +5,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static utility.HttpRequestUtils.HTTP_VERSION;
+import static utility.HttpRequestUtils.PATH;
 
 public class HttpRequestUtilsTest {
 
     @Test
     public void Given_ValidQueryString_When_parseQueryString_Then_AsExpected() {
         // given
-        String query = "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net";
+        String query = "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net";
 
         Map<String, String> expect = new HashMap<>();
 
@@ -37,7 +39,7 @@ public class HttpRequestUtilsTest {
     @Test
     public void Given_EmptyQuery_When_parseQueryString_Then_Null() {
         // given
-        String query = "/user/create";
+        String query = "";
 
         // when
         Map<String, String> queryParams = HttpRequestUtils.parseQueryString(query);
@@ -47,14 +49,35 @@ public class HttpRequestUtilsTest {
     }
 
     @Test
-    public void Given_NotValidQuery_When_parseQueryString_Then_Null() {
-        // given
-        String query = "/user/create?";
+    public void Given_RequestLineWithQueryString_When_ParseRequestLine_Then_AsExpected() {
+        String requestLine = "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1";
+
+        Map<String, String> expectQuery = new HashMap<>();
+
+        expectQuery.put("userId", "javajigi");
+        expectQuery.put("password", "password");
+        expectQuery.put("name", "%EB%B0%95%EC%9E%AC%EC%84%B1");
+        expectQuery.put("email", "javajigi%40slipp.net");
 
         // when
-        Map<String, String> queryParams = HttpRequestUtils.parseQueryString(query);
+        Map<String, String> request = HttpRequestUtils.parseRequestLine(requestLine);
 
         // then
-        assertNull(queryParams);
+        assertNotNull(request);
+
+        // QueryString Parsing 테스트
+        for(Map.Entry<String, String> expected : expectQuery.entrySet()) {
+            String key = expected.getKey();
+            String value = expected.getValue();
+
+            assertEquals(value, expectQuery.get(key));
+        }
+
+        // Path Test
+        assertEquals("/user/create", request.get(PATH));
+
+        // Http Version Test
+        assertEquals("HTTP/1.1", request.get(HTTP_VERSION));
+
     }
 }


### PR DESCRIPTION
## What
* RequestHandler 리소스 반환 역할 RequestController 클래스에 위임
<img width="1037" alt="스크린샷 2023-01-11 오후 5 44 15" src="https://user-images.githubusercontent.com/33480561/211759663-49c4caf8-da0f-4d6b-bb91-cfddb5458568.png">

* statusCode, Content-Type 등 Response Header와 관련된 필드 가지는 HttpResponse 객체 추가

## Why
정적 리소스 반환, 비즈니스 로직 처리 모두 RequestHandler 의 run() 메서드가 담당하면 uri에 따라, 정적 / 동적 리소스 요청에 따른 분기가 많아지는 문제가 존재. 이를 경감시키기 위해 RequestController 클래스의 staticRequestHandler, dynamicRequestHandler 메서드로 각각 정적 리소스 반환, 비즈니스 로직 처리 역할을 나눔

## How

### RequestHandler 의 run() 메서드의 리소스 반환 역할 분리

<img width="661" alt="스크린샷 2023-01-11 오후 5 48 40" src="https://user-images.githubusercontent.com/33480561/211760191-c824a548-9d1d-4106-a390-ea7aaa35889e.png">

이후, 각 메서드는 uri에 따라 적절한 처리 후, HttpResponse 생성 및 반환

<img width="690" alt="스크린샷 2023-01-11 오후 5 50 49" src="https://user-images.githubusercontent.com/33480561/211760592-02a9a151-b826-4d66-ac69-d2b90223e9b1.png">
