### PR TITLE
[이재훈] Step3 리팩토링 및 Step4 구현

### DIFF
--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -1,0 +1,30 @@
+package controller;
+
+import util.HttpStatus;
+import view.RequestHeaderMessage;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public interface Controller {
+
+    void control();
+    default byte[] getBodyFile(String fileURL){
+        if (fileURL.contains(".")) {  //파일을 요청 (.html, .js, .css etc..)
+            try {
+                return Files.readAllBytes(new File(fileURL).toPath());
+            } catch (IOException e){
+                //logger.debug(e.getMessage());
+            }
+        }
+        return new byte[0];
+    }
+
+    default HttpStatus setHttpStatus(byte[] body){
+        if (body.length > 0)
+            return HttpStatus.Success;
+        return HttpStatus.ClientError;
+    }
+
+}

--- a/src/main/java/controller/StaticController.java
+++ b/src/main/java/controller/StaticController.java
@@ -1,0 +1,36 @@
+package controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import util.HttpStatus;
+import view.RequestHeaderMessage;
+import view.Response;
+import webserver.RequestHandler;
+
+import java.io.DataOutputStream;
+import java.io.OutputStream;
+
+public class StaticController implements Controller{
+    private static final Logger logger = LoggerFactory.getLogger(StaticController.class);
+    private static final String RELATIVE_PATH = "./src/main/resources/static";
+    byte[] body = new byte[0];
+    private HttpStatus httpStatus = HttpStatus.ClientError;
+    private OutputStream out;
+    private RequestHeaderMessage requestHeaderMessage;
+    public StaticController(RequestHeaderMessage requestHeaderMessage, OutputStream out){
+        String fileURL = RELATIVE_PATH + requestHeaderMessage.getHttpOnlyURL();
+        this.out = out;
+        this.requestHeaderMessage = requestHeaderMessage;
+        body = getBodyFile(fileURL);
+        httpStatus = setHttpStatus(body);
+    }
+    @Override
+    public void control() {
+        Response response = new Response(new DataOutputStream(out));
+        response.response(body,requestHeaderMessage, httpStatus);
+    }
+
+    public String toString(){
+        return "StaticController: request " + requestHeaderMessage.getHttpOnlyURL();
+    }
+}

--- a/src/main/java/controller/TemplatesController.java
+++ b/src/main/java/controller/TemplatesController.java
@@ -1,0 +1,38 @@
+package controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import util.HttpStatus;
+import view.RequestHeaderMessage;
+import view.Response;
+import webserver.RequestHandler;
+
+import java.io.DataOutputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+
+//Todo: 일단 tmpelates와 static controller를 나누긴 하였는데, 공통 기능이 대부분이라서 추후 합쳐질 수도 있음
+public class TemplatesController implements Controller{
+    private static final Logger logger = LoggerFactory.getLogger(TemplatesController.class);
+    private static final String RELATIVE_PATH = "./src/main/resources/templates";
+    byte[] body = new byte[0];
+    private HttpStatus httpStatus = HttpStatus.ClientError;
+    private OutputStream out;
+    private RequestHeaderMessage requestHeaderMessage;
+    public TemplatesController(RequestHeaderMessage requestHeaderMessage, OutputStream out){
+        String fileURL = RELATIVE_PATH + requestHeaderMessage.getHttpOnlyURL();
+        this.requestHeaderMessage = requestHeaderMessage;
+        this.out = out;
+        body = getBodyFile(fileURL);
+        httpStatus = setHttpStatus(body);
+    }
+    @Override
+    public void control() {
+        Response response = new Response(new DataOutputStream(out));
+        response.response(body,requestHeaderMessage, httpStatus);
+    }
+
+    public String toString(){
+        return "TemplatesController: request " + requestHeaderMessage.getHttpOnlyURL();
+    }
+}

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -71,10 +71,10 @@ public class UserController implements Controller{
     }
 
     private void userLogin(){
-        Map<String,String> userLogin;
-        userLogin = MessageParser.parseQueryString(requestBodyMessage.getQueryString());
+        Map<String,String> loginInfo;
+        loginInfo = MessageParser.parseQueryString(requestBodyMessage.getQueryString());
         try {
-            User user = userService.findOneUser(userLogin.get(USER_ID)).orElseThrow(IllegalStateException::new);
+            User user = userService.login(loginInfo.get(USER_ID), loginInfo.get(PASSWORD));
             setLocation(Redirect.getRedirectLink(requestHeaderMessage.getRequestAttribute()));
         } catch (IllegalStateException e){
             setLocation("/user/login_failed.html");

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -50,6 +50,10 @@ public class UserController implements Controller{
             userCreate();
             return;
         }
+        if (requestHeaderMessage.getRequestAttribute().equals("/login")){
+            userLogin();
+            return;
+        }
     }
 
     private void userCreate(){
@@ -59,9 +63,21 @@ public class UserController implements Controller{
         else userInfo = MessageParser.parseQueryString(requestBodyMessage.getQueryString());
         try{
             userService.join(new User(userInfo.get(USER_ID),userInfo.get(PASSWORD),userInfo.get(NAME),userInfo.get(EMAIL)));
-            setLocation(Redirect.getRedirectLink(requestHeaderMessage.getHttpOnlyURL()));
+            setLocation(Redirect.getRedirectLink(requestHeaderMessage.getRequestAttribute()));
         } catch (IllegalStateException e){
             setLocation("/user/form_failed.html");
+            logger.debug(e.getMessage());
+        }
+    }
+
+    private void userLogin(){
+        Map<String,String> userLogin;
+        userLogin = MessageParser.parseQueryString(requestBodyMessage.getQueryString());
+        try {
+            User user = userService.findOneUser(userLogin.get(USER_ID)).orElseThrow(IllegalStateException::new);
+            setLocation(Redirect.getRedirectLink(requestHeaderMessage.getRequestAttribute()));
+        } catch (IllegalStateException e){
+            setLocation("/user/login_failed.html");
             logger.debug(e.getMessage());
         }
     }

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -1,0 +1,71 @@
+package controller;
+
+import model.domain.User;
+import model.repository.MemoryUserRepository;
+import model.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import util.HttpRequestUtil;
+import util.HttpStatus;
+import util.Redirect;
+import view.RequestHeaderMessage;
+import view.Response;
+import java.io.DataOutputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+public class UserController implements Controller{
+    private static final Logger logger = LoggerFactory.getLogger(UserController.class);
+    private static final String RELATIVE_PATH = "./src/main/resources";
+    private static final String USER_ID = "userId";
+    private static final String PASSWORD = "password";
+    private static final String NAME = "name";
+    private static final String EMAIL = "email";
+    private Map<String,String> headerKV= new HashMap<>();
+    byte[] body = new byte[0];
+    private HttpStatus httpStatus = HttpStatus.ClientError;
+    private RequestHeaderMessage requestHeaderMessage;
+    private UserService userService = new UserService(new MemoryUserRepository());
+    private OutputStream out;
+    public UserController(){};
+    public UserController(RequestHeaderMessage requestHeaderMessage, OutputStream out){
+        this.requestHeaderMessage = requestHeaderMessage;
+        this.out = out;
+    }
+    @Override
+    public void control() {
+        userCommand();
+        Response response = new Response(new DataOutputStream(out));
+        response.response(body,requestHeaderMessage, httpStatus, headerKV);
+    }
+
+    public void userCommand(){
+        if (requestHeaderMessage.getRequestAttribute().equals("/create")){
+            try{
+                userCreate(requestHeaderMessage);
+                setLocation(Redirect.getRedirectLink(requestHeaderMessage.getHttpOnlyURL()));
+            } catch (IllegalStateException e){
+                setLocation("/user/form.html");
+                logger.debug(e.getMessage());
+            }
+        }
+    }
+
+    private void userCreate(RequestHeaderMessage requestHeaderMessage){
+        Map<String,String> userInfo = HttpRequestUtil.parseQueryString(requestHeaderMessage.getHttpReqParams());
+        userService.join(new User(userInfo.get(USER_ID),userInfo.get(PASSWORD),userInfo.get(NAME),userInfo.get(EMAIL)));
+    }
+
+    private void setLocation(String redirectLink){
+        if (!redirectLink.equals("")){
+            httpStatus = HttpStatus.Redirection;
+            headerKV.put("Location",redirectLink);
+        }
+    }
+
+    public String toString(){
+        return "UserController: request " + requestHeaderMessage.getHttpOnlyURL();
+    }
+
+}

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 public class UserController implements Controller{
     private static final Logger logger = LoggerFactory.getLogger(UserController.class);
-    private static final String RELATIVE_PATH = "./src/main/resources";
     private static final String USER_ID = "userId";
     private static final String PASSWORD = "password";
     private static final String NAME = "name";

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -48,13 +48,8 @@ public class UserController implements Controller{
 
     public void userCommand(){
         if (requestHeaderMessage.getRequestAttribute().equals("/create")){
-            try{
-                //userCreateByGet(requestHeaderMessage);
-                userCreate();
-            } catch (IllegalStateException e){
-                setLocation("/user/form.html");
-                logger.debug(e.getMessage());
-            }
+            userCreate();
+            return;
         }
     }
 
@@ -63,8 +58,13 @@ public class UserController implements Controller{
         if (requestBodyMessage.getQueryString().equals(""))
             userInfo = MessageParser.parseQueryString(requestHeaderMessage.getHttpReqParams());
         else userInfo = MessageParser.parseQueryString(requestBodyMessage.getQueryString());
-        userService.join(new User(userInfo.get(USER_ID),userInfo.get(PASSWORD),userInfo.get(NAME),userInfo.get(EMAIL)));
-        setLocation(Redirect.getRedirectLink(requestHeaderMessage.getHttpOnlyURL()));
+        try{
+            userService.join(new User(userInfo.get(USER_ID),userInfo.get(PASSWORD),userInfo.get(NAME),userInfo.get(EMAIL)));
+            setLocation(Redirect.getRedirectLink(requestHeaderMessage.getHttpOnlyURL()));
+        } catch (IllegalStateException e){
+            setLocation("/user/form.html");
+            logger.debug(e.getMessage());
+        }
     }
 
     private void setLocation(String redirectLink){

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -5,7 +5,7 @@ import model.repository.MemoryUserRepository;
 import model.service.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import util.HttpRequestUtil;
+import util.MessageParser;
 import util.HttpStatus;
 import util.Redirect;
 import view.RequestHeaderMessage;
@@ -53,7 +53,7 @@ public class UserController implements Controller{
     }
 
     private void userCreateByGet(RequestHeaderMessage requestHeaderMessage){
-        Map<String,String> userInfo = HttpRequestUtil.parseQueryString(requestHeaderMessage.getHttpReqParams());
+        Map<String,String> userInfo = MessageParser.parseQueryString(requestHeaderMessage.getHttpReqParams());
         userService.join(new User(userInfo.get(USER_ID),userInfo.get(PASSWORD),userInfo.get(NAME),userInfo.get(EMAIL)));
         setLocation(Redirect.getRedirectLink(requestHeaderMessage.getHttpOnlyURL()));
     }

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -61,7 +61,7 @@ public class UserController implements Controller{
             userService.join(new User(userInfo.get(USER_ID),userInfo.get(PASSWORD),userInfo.get(NAME),userInfo.get(EMAIL)));
             setLocation(Redirect.getRedirectLink(requestHeaderMessage.getHttpOnlyURL()));
         } catch (IllegalStateException e){
-            setLocation("/user/form.html");
+            setLocation("/user/form_failed.html");
             logger.debug(e.getMessage());
         }
     }

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -43,8 +43,8 @@ public class UserController implements Controller{
     public void userCommand(){
         if (requestHeaderMessage.getRequestAttribute().equals("/create")){
             try{
-                userCreate(requestHeaderMessage);
-                setLocation(Redirect.getRedirectLink(requestHeaderMessage.getHttpOnlyURL()));
+                //userCreateByGet(requestHeaderMessage);
+                userCreateByPost();
             } catch (IllegalStateException e){
                 setLocation("/user/form.html");
                 logger.debug(e.getMessage());
@@ -52,9 +52,14 @@ public class UserController implements Controller{
         }
     }
 
-    private void userCreate(RequestHeaderMessage requestHeaderMessage){
+    private void userCreateByGet(RequestHeaderMessage requestHeaderMessage){
         Map<String,String> userInfo = HttpRequestUtil.parseQueryString(requestHeaderMessage.getHttpReqParams());
         userService.join(new User(userInfo.get(USER_ID),userInfo.get(PASSWORD),userInfo.get(NAME),userInfo.get(EMAIL)));
+        setLocation(Redirect.getRedirectLink(requestHeaderMessage.getHttpOnlyURL()));
+    }
+
+    private void userCreateByPost(){
+
     }
 
     private void setLocation(String redirectLink){

--- a/src/main/java/model/service/UserService.java
+++ b/src/main/java/model/service/UserService.java
@@ -37,4 +37,12 @@ public class UserService {
         return userRepository.findUserById(userId);
     }
 
+    public User login(String userId, String password){
+        User user = findOneUser(userId).orElseThrow(()->new IllegalStateException("존재하지 않는 계정입니다."));
+        if (!user.getPassword().equals(password))
+            throw new IllegalStateException("존재하지 않는 계정입니다.");
+        return user;
+    }
+
+
 }

--- a/src/main/java/util/MessageParser.java
+++ b/src/main/java/util/MessageParser.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class HttpRequestUtil {
+public class MessageParser {
     public static Map<String,String> parseQueryString(String reqURLParams){
         Map<String,String> info = new HashMap<>();
         try{

--- a/src/main/java/util/MessageParser.java
+++ b/src/main/java/util/MessageParser.java
@@ -6,10 +6,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class MessageParser {
-    public static Map<String,String> parseQueryString(String reqURLParams){
+    public static Map<String,String> parseQueryString(String queryString){
         Map<String,String> info = new HashMap<>();
         try{
-            String[] infoSet = reqURLParams.split("&");
+            String[] infoSet = queryString.split("&");
             info = Stream.of(infoSet).map(s->s.split("=")).collect(Collectors.toMap(a->a[0],a->a[1]));
         }catch (ArrayIndexOutOfBoundsException e){
         }

--- a/src/main/java/util/Redirect.java
+++ b/src/main/java/util/Redirect.java
@@ -6,14 +6,17 @@ import java.util.stream.Stream;
 
 public class Redirect {
     private static Map<String, String> redirectLink = new HashMap<>(){{
-        put("create","/index.html");
+        put("/create","/index.html");
+        put("/login","/index.html");
     }};
 
-    public static String getRedirectLink(String reqURL){
+    public static String getRedirectLink(String reqAttribute){
+        /*
         for (String key: redirectLink.keySet()){
             if (reqURL.contains(key))
                 return redirectLink.get(key);
         }
-        return "";
+         */
+        return redirectLink.getOrDefault(reqAttribute,"");
     }
 }

--- a/src/main/java/view/RequestBodyMessage.java
+++ b/src/main/java/view/RequestBodyMessage.java
@@ -1,0 +1,4 @@
+package view;
+
+public class RequestBodyMessage {
+}

--- a/src/main/java/view/RequestBodyMessage.java
+++ b/src/main/java/view/RequestBodyMessage.java
@@ -1,4 +1,13 @@
 package view;
 
 public class RequestBodyMessage {
+
+    private String queryString = "";
+
+    public String getQueryString() {
+        return queryString;
+    }
+    public RequestBodyMessage(char[] body){
+        this.queryString = new String(body);
+    }
 }

--- a/src/main/java/view/RequestHeaderMessage.java
+++ b/src/main/java/view/RequestHeaderMessage.java
@@ -1,7 +1,7 @@
 package view;
 
 import com.google.common.io.Files;
-import util.HttpRequestUtil;
+import util.MessageParser;
 
 public class RequestHeaderMessage {
     private String httpFirstHeader;
@@ -39,10 +39,10 @@ public class RequestHeaderMessage {
     }
 
     private void parseHttpReqURL(String httpReqURL){
-        this.httpOnlyURL = HttpRequestUtil.getOnlyURL(httpReqURL);
-        this.httpReqParams = HttpRequestUtil.getURLParams(httpReqURL);
+        this.httpOnlyURL = MessageParser.getOnlyURL(httpReqURL);
+        this.httpReqParams = MessageParser.getURLParams(httpReqURL);
         this.fileExtension = Files.getFileExtension(httpOnlyURL);
-        this.requestAttribute = HttpRequestUtil.getRequestAttribute(httpOnlyURL);
+        this.requestAttribute = MessageParser.getRequestAttribute(httpOnlyURL);
         this.contentType = "text/" + (fileExtension.equals("js")?"javascript":fileExtension);
     }
 

--- a/src/main/java/view/RequestMessage.java
+++ b/src/main/java/view/RequestMessage.java
@@ -2,8 +2,8 @@ package view;
 
 public class RequestMessage {
 
-    RequestHeaderMessage requestHeaderMessage;
-    RequestBodyMessage requestBodyMessage;
+    private RequestHeaderMessage requestHeaderMessage;
+    private RequestBodyMessage requestBodyMessage;
 
     public RequestHeaderMessage getRequestHeaderMessage() {
         return requestHeaderMessage;

--- a/src/main/java/view/RequestMessage.java
+++ b/src/main/java/view/RequestMessage.java
@@ -1,0 +1,20 @@
+package view;
+
+public class RequestMessage {
+
+    RequestHeaderMessage requestHeaderMessage;
+    RequestBodyMessage requestBodyMessage;
+
+    public RequestHeaderMessage getRequestHeaderMessage() {
+        return requestHeaderMessage;
+    }
+
+    public RequestBodyMessage getRequestBodyMessage() {
+        return requestBodyMessage;
+    }
+
+    public RequestMessage(RequestHeaderMessage requestHeaderMessage, RequestBodyMessage requestBodyMessage){
+        this.requestHeaderMessage = requestHeaderMessage;
+        this.requestBodyMessage = requestBodyMessage;
+    }
+}

--- a/src/main/java/view/Response.java
+++ b/src/main/java/view/Response.java
@@ -17,6 +17,12 @@ public class Response {
     public Response(DataOutputStream dos){
         this.dos = dos;
     }
+
+    public void response(byte[] body, RequestHeaderMessage requestHeaderMessage, HttpStatus httpStatus){
+        responseHeader(requestHeaderMessage,body,httpStatus,new HashMap<>());
+        responseBody(body);
+    }
+
     public void response(byte[] body, RequestHeaderMessage requestHeaderMessage, HttpStatus httpStatus, Map<String,String> header){
         responseHeader(requestHeaderMessage,body,httpStatus,header);
         responseBody(body);

--- a/src/main/java/view/StartLine.java
+++ b/src/main/java/view/StartLine.java
@@ -1,0 +1,4 @@
+package view;
+
+public class StartLine {
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,6 +2,9 @@ package webserver;
 
 import java.io.*;
 import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+
 import controller.Controller;
 import controller.StaticController;
 import controller.TemplatesController;
@@ -9,7 +12,9 @@ import controller.UserController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import util.HttpStatus;
+import view.RequestBodyMessage;
 import view.RequestHeaderMessage;
+import view.RequestMessage;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
@@ -27,11 +32,26 @@ public class RequestHandler implements Runnable {
             httpStatus = HttpStatus.ClientError;
             InputStreamReader reader = new InputStreamReader(in);
             BufferedReader br = new BufferedReader(reader);
-            RequestHeaderMessage requestHeaderMessage = new RequestHeaderMessage(br.readLine());
-            setController(requestHeaderMessage, out);
-            logger.debug(controller.toString());
+            RequestMessage requestMessage = new RequestMessage(new RequestHeaderMessage(br.readLine()), new RequestBodyMessage());
+            //RequestHeaderMessage requestHeaderMessage = new RequestHeaderMessage(br.readLine());
+            String brStr = "";
+            boolean bodyExist = false;
+            char[] body = new char[0];
+            int body_sz = 0;
+            while(!(brStr=br.readLine()).equals("")){
+                int idx = -1;
+                if (brStr.contains("Content-Length")){
+                    body_sz = Integer.parseInt(brStr.substring("Content-Length: ".length()));
+                    body = new char[body_sz];
+                }
+                logger.debug(brStr);
+            }
+            br.read(body);
+            logger.debug(new String(body));
 
-            while(!(br.readLine()).equals("")){}
+            //System.out.println(br.readLine());
+            setController(requestMessage.getRequestHeaderMessage(), out);
+            logger.debug(controller.toString());
             controller.control();
         } catch (IOException e) {
             logger.error(e.getMessage());
@@ -43,7 +63,7 @@ public class RequestHandler implements Runnable {
             controller = new TemplatesController(requestHeaderMessage, out);
             return;
         }
-        if (requestHeaderMessage.getHttpOnlyURL().contains(".")) {
+            if (requestHeaderMessage.getHttpOnlyURL().contains(".")) {
             controller = new StaticController(requestHeaderMessage, out);
             return;
         }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -48,8 +48,6 @@ public class RequestHandler implements Runnable {
             }
             br.read(body);
             logger.debug(new String(body));
-
-            //System.out.println(br.readLine());
             setController(requestMessage.getRequestHeaderMessage(), out);
             logger.debug(controller.toString());
             controller.control();

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -32,7 +32,7 @@ public class RequestHandler implements Runnable {
             httpStatus = HttpStatus.ClientError;
             InputStreamReader reader = new InputStreamReader(in);
             BufferedReader br = new BufferedReader(reader);
-            RequestMessage requestMessage = new RequestMessage(new RequestHeaderMessage(br.readLine()), new RequestBodyMessage());
+            String startLine = br.readLine();
             //RequestHeaderMessage requestHeaderMessage = new RequestHeaderMessage(br.readLine());
             String brStr = "";
             boolean bodyExist = false;
@@ -48,7 +48,8 @@ public class RequestHandler implements Runnable {
             }
             br.read(body);
             logger.debug(new String(body));
-            setController(requestMessage.getRequestHeaderMessage(), out);
+            RequestMessage requestMessage = new RequestMessage(new RequestHeaderMessage(startLine), new RequestBodyMessage(body));
+            setController(requestMessage, out);
             logger.debug(controller.toString());
             controller.control();
         } catch (IOException e) {
@@ -56,7 +57,8 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private void setController(RequestHeaderMessage requestHeaderMessage, OutputStream out){
+    private void setController(RequestMessage requestMessage, OutputStream out){
+        RequestHeaderMessage requestHeaderMessage = requestMessage.getRequestHeaderMessage();
         if (requestHeaderMessage.getContentType().contains("html")){
             controller = new TemplatesController(requestHeaderMessage, out);
             return;
@@ -66,7 +68,7 @@ public class RequestHandler implements Runnable {
             return;
         }
         if (requestHeaderMessage.getHttpOnlyURL().startsWith("/user")) {
-            controller = new UserController(requestHeaderMessage, out);
+            controller = new UserController(requestMessage, out);
             return;
         }
     }

--- a/src/main/resources/templates/user/form.html
+++ b/src/main/resources/templates/user/form.html
@@ -75,7 +75,7 @@
 <div class="container" id="main">
    <div class="col-md-6 col-md-offset-3">
       <div class="panel panel-default content-main">
-          <form name="question" method="get" action="/user/create">
+          <form name="question" method="post" action="/user/create">
               <div class="form-group">
                   <label for="userId">사용자 아이디</label>
                   <input class="form-control" id="userId" name="userId" placeholder="User ID">

--- a/src/main/resources/templates/user/form_failed.html
+++ b/src/main/resources/templates/user/form_failed.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="kr">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta charset="utf-8">
+    <title>SLiPP Java Web Programming</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link href="../css/bootstrap.min.css" rel="stylesheet">
+    <!--[if lt IE 9]>
+    <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+    <link href="../css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-fixed-top header">
+    <div class="col-md-12">
+        <div class="navbar-header">
+
+            <a href="../index.html" class="navbar-brand">SLiPP</a>
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse1">
+                <i class="glyphicon glyphicon-search"></i>
+            </button>
+
+        </div>
+        <div class="collapse navbar-collapse" id="navbar-collapse1">
+            <form class="navbar-form pull-left">
+                <div class="input-group" style="max-width:470px;">
+                    <input type="text" class="form-control" placeholder="Search" name="srch-term" id="srch-term">
+                    <div class="input-group-btn">
+                        <button class="btn btn-default btn-primary" type="submit"><i class="glyphicon glyphicon-search"></i></button>
+                    </div>
+                </div>
+            </form>
+            <ul class="nav navbar-nav navbar-right">
+                <li>
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="glyphicon glyphicon-bell"></i></a>
+                    <ul class="dropdown-menu">
+                        <li><a href="https://slipp.net" target="_blank">SLiPP</a></li>
+                        <li><a href="https://facebook.com" target="_blank">Facebook</a></li>
+                    </ul>
+                </li>
+                <li><a href="../user/list.html"><i class="glyphicon glyphicon-user"></i></a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<div class="navbar navbar-default" id="subnav">
+    <div class="col-md-12">
+        <div class="navbar-header">
+            <a href="#" style="margin-left:15px;" class="navbar-btn btn btn-default btn-plus dropdown-toggle" data-toggle="dropdown"><i class="glyphicon glyphicon-home" style="color:#dd1111;"></i> Home <small><i class="glyphicon glyphicon-chevron-down"></i></small></a>
+            <ul class="nav dropdown-menu">
+                <li><a href="../user/profile.html"><i class="glyphicon glyphicon-user" style="color:#1111dd;"></i> Profile</a></li>
+                <li class="nav-divider"></li>
+                <li><a href="#"><i class="glyphicon glyphicon-cog" style="color:#dd1111;"></i> Settings</a></li>
+            </ul>
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse2">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+        </div>
+        <div class="collapse navbar-collapse" id="navbar-collapse2">
+            <ul class="nav navbar-nav navbar-right">
+                <li class="active"><a href="../index.html">Posts</a></li>
+                <li><a href="../user/login.html" role="button">로그인</a></li>
+                <li><a href="../user/form.html" role="button">회원가입</a></li>
+                <li><a href="#" role="button">로그아웃</a></li>
+                <li><a href="#" role="button">개인정보수정</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<div class="container" id="main">
+    <div class="col-md-6 col-md-offset-3">
+        <div class="panel panel-default content-main">
+            <div class="alert alert-danger" role="alert">이미 존재하는 아이디입니다. 다른 아이디를 사용해주세요.</div>
+            <form name="question" method="post" action="/user/create">
+                <div class="form-group">
+                    <label for="userId">사용자 아이디</label>
+                    <input class="form-control" id="userId" name="userId" placeholder="User ID">
+                </div>
+                <div class="form-group">
+                    <label for="password">비밀번호</label>
+                    <input type="password" class="form-control" id="password" name="password" placeholder="Password">
+                </div>
+                <div class="form-group">
+                    <label for="name">이름</label>
+                    <input class="form-control" id="name" name="name" placeholder="Name">
+                </div>
+                <div class="form-group">
+                    <label for="email">이메일</label>
+                    <input type="email" class="form-control" id="email" name="email" placeholder="Email">
+                </div>
+                <button type="button" class="btn btn-success clearfix pull-right" onclick="emptyChk()">회원가입</button>
+                <div class="clearfix" />
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- script references -->
+<script src="../js/jquery-2.2.0.min.js"></script>
+<script src="../js/bootstrap.min.js"></script>
+<script src="../js/scripts.js"></script>
+</body>
+</html>

--- a/src/test/java/util/MessageParserTest.java
+++ b/src/test/java/util/MessageParserTest.java
@@ -6,14 +6,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
-class HttpRequestUtilTest {
+class MessageParserTest {
 
     @Test
     void parseQueryStringTest() {
         String queryString = "userId=testId&password=testPW&name=testName&email=test%40mail.com";
-        Map<String,String> info = HttpRequestUtil.parseQueryString(queryString);
+        Map<String,String> info = MessageParser.parseQueryString(queryString);
         Map<String, String> user = new HashMap<>(){{
             put("userId", "testId");
             put("password", "testPW");
@@ -28,28 +27,28 @@ class HttpRequestUtilTest {
     void getOnlyURLTest() {
         String reqURL = "/user/create?userId=testId&password=testPW&name=testName&email=test%40mail.com";
         String onlyURL = "/user/create";
-        assertThat(HttpRequestUtil.getOnlyURL(reqURL)).isEqualTo(onlyURL);
+        assertThat(MessageParser.getOnlyURL(reqURL)).isEqualTo(onlyURL);
     }
 
     @Test
     void getURLParamsTest() {
         String reqURL = "/user/create?userId=testId&password=testPW&name=testName&email=test%40mail.com";
         String onlyURL = "userId=testId&password=testPW&name=testName&email=test%40mail.com";
-        assertThat(HttpRequestUtil.getURLParams(reqURL)).isEqualTo(onlyURL);
+        assertThat(MessageParser.getURLParams(reqURL)).isEqualTo(onlyURL);
     }
 
     @Test
     void getURLParamsExceptionTest(){
         String reqURL = "/index.html";
         String onlyURL = "";
-        assertThat(HttpRequestUtil.getURLParams(reqURL)).isEqualTo(onlyURL);
+        assertThat(MessageParser.getURLParams(reqURL)).isEqualTo(onlyURL);
     }
 
     @Test
     void getRequestAttributeTest() {
         String onlyURL = "/user/create";
         String reqAttribute = "/create";
-        assertThat(HttpRequestUtil.getRequestAttribute(onlyURL)).isEqualTo(reqAttribute);
+        assertThat(MessageParser.getRequestAttribute(onlyURL)).isEqualTo(reqAttribute);
     }
 
 


### PR DESCRIPTION
## Done
+ Static, Templates, User controller 생성 후 각 request에 맞는 controller가 처리
+ content-length와 bufferedReader의 read 활용하여 request message의 body 읽기. http message의 경우 eof이 없기 때문에 readline은 사용 불가
+ HttpUtilRequest -> MessageParser로 클래스 rename
+ userController에서 body 내용이 있으면 post, 없으면 get으로 판단
+ RequestHeaderMessage, RequestBodyMessage 클래스를 포함하는 RequestMessage 클래스 생성
+ 중복 아이디 회원가입 시 리다이렉션용 html 생성 및 예외 처리 setLocation 위치 변경
+ 로그인 기능 일부 구현. 현 상태: 유저 아이디만 검사 후 로그인 성공 시 index.html. 비밀번호 검사는 service에는 구현하였으며 아직 controller에 적용하지 않은 상태.
+ 매칭되는 아이디 없을 시 login_failed로 리다이렉션

## Todo
+ 로그인 시 비밀번호까지 검사하여 최종 처리
+ 로그인 성공 시 쿠키 및 세션 설정